### PR TITLE
Upgrade the `template-haskell` dependency to work with the latest Stackage LTS

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,7 @@ library:
   - th-orphans
   - monad-control >= 1.0.0.0 && < 2
   - mtl
-  - template-haskell >= 2.10.0.0 && < 2.13
+  - template-haskell >= 2.10.0.0 && < 2.14
   - transformers-base
   when:
   - condition: impl(ghc < 8)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.20
+resolver: lts-12.7
 
 packages:
 - '.'


### PR DESCRIPTION
I apologize if this isn't an OK change to request. Also, if it does look good, I'm not totally sure how best to manually test that everything's still working.