### PR TITLE
feat: update dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ extra-source-files:
 - stack.yaml
 
 ghc-options: -Wall
+
 default-extensions:
 - DefaultSignatures
 - FlexibleContexts
@@ -40,15 +41,15 @@ default-extensions:
 
 library:
   dependencies:
-  - base >= 4.8.0.0 && < 5
-  - constraints >= 0.3.1
-  - exceptions >= 0.6
+  - base
+  - constraints
+  - exceptions
   - haskell-src-exts
   - haskell-src-meta
   - th-orphans
-  - monad-control >= 1.0.0.0 && < 2
+  - monad-control
   - mtl
-  - template-haskell >= 2.10.0.0 && < 2.13
+  - template-haskell
   - transformers-base
   when:
   - condition: impl(ghc < 8)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.20
+resolver: lts-13.19
 
 packages:
 - '.'


### PR DESCRIPTION
This probably doesnt fix https://github.com/cjdev/monad-mock/issues/9 `stack configuration has no specified version` but at least it allows to install monad-mock using (without update it  throws that dependencies are old)

```
extra-deps:
  - git: https://github.com/srghma/monad-mock.git
    commit: 508a763e63830d3e8f4f60669e3a9272ec361c4c
```